### PR TITLE
Improve search

### DIFF
--- a/site-observable/docs/data/films.sqlite.py
+++ b/site-observable/docs/data/films.sqlite.py
@@ -26,7 +26,38 @@ with tempfile.TemporaryDirectory() as temp_dir:
     df = df[df["release_date"] < now]
 
     # Remove movies with no known revenue
-    df = df[df["revenue"] > 0]
+    # and original_language other than EU languages
+    df = df[
+        (df["revenue"] == 0)
+        & (
+            df["original_language"].isin(
+                [
+                    "cs",
+                    "da",
+                    "de",
+                    "en",
+                    "es",
+                    "et",
+                    "fi",
+                    "fr",
+                    "hr",
+                    "hu",
+                    "is",
+                    "it",
+                    "lt",
+                    "lv",
+                    "nl",
+                    "no",
+                    "pl",
+                    "pt",
+                    "ro",
+                    "sl",
+                    "sv",
+                ],
+            )
+        )
+        | (df["revenue"] > 0)
+    ]
 
     # Add a column with the production_year based on the release_date
     df["production_year"] = df["release_date"].dt.year

--- a/site-observable/docs/films.md
+++ b/site-observable/docs/films.md
@@ -24,7 +24,7 @@ const db = FileAttachment("data/films.sqlite").sqlite();
 ```js
 const results = db.query(
   `SELECT *, (SELECT COUNT(*) FROM films) total FROM films WHERE films.title LIKE ? COLLATE NOCASE ORDER BY films.title LIMIT 20`,
-  [`${query}%`]
+  [`%${query}%`]
 );
 ```
 

--- a/site-observable/docs/films.md
+++ b/site-observable/docs/films.md
@@ -23,8 +23,20 @@ const db = FileAttachment("data/films.sqlite").sqlite();
 
 ```js
 const results = db.query(
-  `SELECT *, (SELECT COUNT(*) FROM films) total FROM films WHERE films.title LIKE ? COLLATE NOCASE ORDER BY films.title LIMIT 20`,
-  [`%${query}%`]
+  `
+  SELECT
+    *,
+    (SELECT COUNT(*) FROM films) total
+  FROM
+    films
+  WHERE
+    films.title LIKE ? COLLATE NOCASE
+    OR films.original_title LIKE ? COLLATE NOCASE
+  ORDER BY
+    films.title
+  LIMIT
+    20`,
+  [`%${query}%`, `%${query}%`]
 );
 ```
 

--- a/site-observable/docs/shows.md
+++ b/site-observable/docs/shows.md
@@ -22,8 +22,19 @@ const db = FileAttachment("data/shows.sqlite").sqlite();
 
 ```js
 const results = db.query(
-  `SELECT *, (SELECT COUNT(*) FROM shows) total FROM shows WHERE shows.name LIKE ? COLLATE NOCASE ORDER BY shows.name ASC LIMIT 20`,
-  [`%${query}%`]
+  `
+  SELECT
+    *,
+    (SELECT COUNT(*) FROM shows) total
+  FROM
+    shows
+  WHERE
+    shows.name LIKE ? COLLATE NOCASE OR
+    shows.original_name LIKE ? COLLATE NOCASE
+  ORDER BY
+    shows.name ASC
+  LIMIT 20`,
+  [`%${query}%`, `%${query}%`]
 );
 ```
 

--- a/site-observable/docs/shows.md
+++ b/site-observable/docs/shows.md
@@ -23,7 +23,7 @@ const db = FileAttachment("data/shows.sqlite").sqlite();
 ```js
 const results = db.query(
   `SELECT *, (SELECT COUNT(*) FROM shows) total FROM shows WHERE shows.name LIKE ? COLLATE NOCASE ORDER BY shows.name ASC LIMIT 20`,
-  [`${query}%`]
+  [`%${query}%`]
 );
 ```
 


### PR DESCRIPTION
Fixes #17 

- fixes issue with too strong filtering rules for films in TMDB related to revenue because for a lot of earlier films revenue is set to zero
- simultaneous search of title and original_title for films
- simultaneous search for name and original_name for shows
- search query can occur anywhere in these columns instead of just at the beginning