### PR TITLE
Disable movies dataset cron schedule and use a fixed number of retries

### DIFF
--- a/.github/workflows/movies.yaml
+++ b/.github/workflows/movies.yaml
@@ -2,7 +2,7 @@ name: Update Movies Dataset
 
 on:
   # Run this workflow once per day, at 0:15 UTC
-  schedule: [{ cron: "15 0 * * *" }]
+  # schedule: [{ cron: "15 0 * * *" }]
   # Run this workflow when triggered manually in GitHub’s UI.
   workflow_dispatch: {}
 
@@ -25,4 +25,4 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # TMDB credentials
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-          TMDB_MAX_RETRIES: ${{ secrets.TMDB_MAX_RETRIES }}
+          TMDB_MAX_RETRIES: 500


### PR DESCRIPTION
- we will create an initial version of the dataset by running the movies script manually then enable the workflow again to run the daily update