### PR TITLE
Really fix deployment to Observable HQ

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: Gr1N/setup-poetry@v9
         with:
           poetry-version: "1.7.1"
-      - run: poetry install --no-root
+      - run: poetry install
       - run: yarn install --frozen-lockfile
       - run: poetry run yarn build
         env:


### PR DESCRIPTION
- Remove left over `--no-root` flag, otherwise the `observatoire` python code isn't installed for use by observable 